### PR TITLE
fix: make generate a T.command

### DIFF
--- a/plugin/src/io/kipp/mill/giter8/G8Module.scala
+++ b/plugin/src/io/kipp/mill/giter8/G8Module.scala
@@ -101,7 +101,7 @@ trait G8Module extends TaskModule {
     * @return
     *   the location of where your project has been generated
     */
-  def generate: Target[Path] = T {
+  def generate: Target[Path] = T.command {
     val log = T.log
     val output = T.dest / "result"
 


### PR DESCRIPTION
Before something could change in your template and it wouldn't re-evaluate.
Now this just forces genereation every time. It's fast so this shouldn't
be a big deal at all
