### PR TITLE
fix: ensure properties are correctly resolved

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -79,10 +79,16 @@ object itest extends MillIntegrationTestModule {
     T {
       Seq(
         PathRef(testBase / "minimal") -> Seq(
-          TestInvocation.Targets(Seq("g8.validate"), noServer = true)
+          TestInvocation.Targets(Seq("g8.validate"), noServer = true),
+          TestInvocation
+            .Targets(Seq("validatePackageStructure"), noServer = true)
         ),
         PathRef(testBase / "no-mill") -> Seq(
-          TestInvocation.Targets(Seq("g8.validate"), noServer = true)
+          TestInvocation.Targets(Seq("g8.validate"), noServer = true),
+          TestInvocation.Targets(
+            Seq("validatePackageStructure"),
+            noServer = true
+          )
         )
       )
     }

--- a/itest/shared/build.sc
+++ b/itest/shared/build.sc
@@ -6,3 +6,13 @@ import munit.Assertions._
 object g8 extends G8Module {
   override def validationTargets = Seq("__.compile")
 }
+
+/** Just tests to ensure that $package$ is actually correctly expanded and the
+  * strucutre looks as it should
+  */
+def validatePackageStructure = T {
+  val expectedFile =
+    T.workspace / "out" / "g8" / "generate.overridden" / "io" / "kipp" / "mill" / "giter8" / "G8Module" / "generate.dest" / "result" / "minimal" / "src" / "com" / "example" / "someproject" / "Main.scala"
+
+  assert(os.exists(expectedFile))
+}

--- a/itest/shared/src/main/g8/default.properties
+++ b/itest/shared/src/main/g8/default.properties
@@ -1,1 +1,5 @@
+name = some project
+organization = com.example
+package = $organization$.$name;format="norm,word"$
+
 verbatim = mill

--- a/itest/shared/src/main/g8/minimal/src/$package$/Main.scala
+++ b/itest/shared/src/main/g8/minimal/src/$package$/Main.scala
@@ -1,3 +1,3 @@
-package minimal
+package $package$
 
 @main def hello = println("hello")


### PR DESCRIPTION
Prior to this change only the maven properties were actually resolved
leaving the rest not. This would cause for example `$package$` to end up
being generated as `$package`. Now we ensure everything that we can is
resolved by mimicking the way it's done in the sbt plugin.

NOTE: I still plan on improving this a bit by allowing the user to pass
in values to validate/generate which can be used to generate with
specific values.

Closes #11
